### PR TITLE
feat: add 60dB AI provider integration for STT, TTS, and LLM services

### DIFF
--- a/apps/soniox-speech-to-speech-translation-demo/.env.example
+++ b/apps/soniox-speech-to-speech-translation-demo/.env.example
@@ -1,1 +1,10 @@
+# Soniox is used for speech-to-text (and optionally text-to-speech).
 SONIOX_API_KEY=your_key_here
+
+# Text-to-speech provider: "sixtydb" (default) or "soniox".
+TTS_PROVIDER=sixtydb
+
+# 60db TTS (used when TTS_PROVIDER=sixtydb).
+SIXTYDB_API_KEY=
+SIXTYDB_VOICE_ID=
+# SIXTYDB_API_BASE=https://api.60db.ai

--- a/apps/soniox-speech-to-speech-translation-demo/README.md
+++ b/apps/soniox-speech-to-speech-translation-demo/README.md
@@ -4,18 +4,31 @@ A small demo that plays speech from an audio file (or from your microphone), tra
 
 The point of the project is to show how to wire the two Soniox WebSocket APIs together at the protocol level - useful if you want to see what an SDK does for you under the hood, or if you need to build something the SDKs don't cover.
 
+Speech-to-text always uses Soniox. The spoken translation (TTS) can be produced by either **Soniox** or **[60db](https://60db.ai)**, selected with the `TTS_PROVIDER` env var. Both backends live behind a common interface in [tts.py](tts.py) and emit the same raw 16-bit PCM at 24 kHz, so the rest of the app doesn't care which one is used.
+
 ## Requirements
 
 - Python (managed via [uv](https://github.com/astral-sh/uv))
-- A Soniox API key
+- A Soniox API key (for STT, and for TTS when `TTS_PROVIDER=soniox`)
+- A 60db API key + voice id (for TTS when `TTS_PROVIDER=sixtydb`, the default)
 
 ## Setup
 
-Create a `.env` file in the project root with your API key (in the format of .env.example):
+Create a `.env` file in the project root (see `.env.example`):
 
 ```
 SONIOX_API_KEY=your_key_here
+
+# TTS provider: "sixtydb" (default) or "soniox"
+TTS_PROVIDER=sixtydb
+
+# Only needed when TTS_PROVIDER=sixtydb
+SIXTYDB_API_KEY=your_60db_key
+SIXTYDB_VOICE_ID=your_60db_voice_id
 ```
+
+> 60db's voice is chosen with `SIXTYDB_VOICE_ID`; the on-page voice dropdown only
+> applies to the Soniox provider.
 
 Install dependencies:
 
@@ -38,7 +51,7 @@ The original transcript appears on the left, the translation on the right. If *E
 
 ## How it works
 
-The backend opens one WebSocket to Soniox STT and (when spoken translation is enabled) one to Soniox TTS, and proxies between them and the browser.
+The backend opens one WebSocket to Soniox STT and (when spoken translation is enabled) drives a TTS backend, proxying between them and the browser. The diagram below shows the Soniox TTS backend; with `TTS_PROVIDER=sixtydb` the TTS leg is instead an HTTP `POST /tts-synthesize` per utterance against 60db, whose WAV response is unwrapped to PCM and streamed to the browser the same way.
 
 ```
 Browser              Python backend              Soniox
@@ -55,32 +68,33 @@ Browser              Python backend              Soniox
    │  ◀── PCM binary ──    │  (decoded)             │
 ```
 
-The browser is a thin client: capture mic with `MediaRecorder` (or play the source file locally for follow-along), send bytes, receive token JSON and PCM audio. All the Soniox protocol work lives in [server/main.py](server/main.py).
+The browser is a thin client: capture mic with `MediaRecorder` (or play the source file locally for follow-along), send bytes, receive token JSON and PCM audio. The STT plumbing lives in [main.py](main.py); the TTS backends live in [tts.py](tts.py).
 
 The `/ws/translate` endpoint takes query params for `target_lang`, `voice`, `lang_id`, `diarize`, `tts` (toggle spoken translation), and optionally `audio_url` + `audio_duration` to put it in file mode.
 
-Per browser connection the backend runs a handful of concurrent coroutines:
+Per browser connection the backend runs a few concurrent coroutines:
 
 - **Input** - one of:
   - **`pipe_browser_audio_to_stt`** (mic mode) forwards mic audio bytes from browser to STT.
   - **`stream_url_to_stt`** (file mode) fetches `audio_url` over HTTP and feeds STT at real-time pace using `audio_duration` to compute the byte rate, so STT sees the file as if it were being spoken live.
 - **`handle_stt`** - reads STT results, forwards them to the browser for UI rendering, and pushes translation tokens into a queue for TTS.
-- **`tts_sender`** *(only when TTS enabled)* - pulls tokens from the queue, opens a new TTS stream per utterance, sends text chunks, closes the stream on `<end>`.
-- **`pipe_tts_to_browser`** *(only when TTS enabled)* - reads audio from TTS, base64-decodes it, forwards it to the browser. Emits a `session_done` message once tts_sender has drained the queue and the last TTS stream has terminated, so the browser knows it's safe to stop.
-- **`tts_keepalive`** *(only when TTS enabled)* - sends a keepalive message every 20 seconds so idle TTS streams don't get killed.
-
-One TTS stream per utterance, sequential. The TTS connection is pre-warmed: the backend opens a TTS stream with a config message as soon as the browser connects, so the first translation token can skip the config round-trip and start producing audio sooner.
+- **`TtsBackend.run`** *(only when TTS enabled)* - the selected TTS backend pulls translated text from the queue and streams PCM to the browser:
+  - **`SonioxTtsBackend`** opens a pre-warmed Soniox TTS WebSocket, one stream per utterance, streams text chunks, and forwards decoded audio (plus a keepalive every 20s). It emits `session_done` once the queue is drained and the last stream has terminated.
+  - **`SixtyDBTtsBackend`** accumulates each utterance's text and, on the utterance boundary, makes one `POST /tts-synthesize` call to 60db, unwraps the returned WAV to PCM, and streams it out. It emits `session_done` when the queue is exhausted.
 
 ## Files
 
 ```
-server/main.py     FastAPI + Soniox WebSocket plumbing
-web/index.html     UI shell
-web/styles.css     Dark theme
-web/app.js         Mic capture + WebSocket + Web Audio playback
+main.py            FastAPI + Soniox STT WebSocket plumbing
+tts.py             TTS backends (Soniox WebSocket / 60db HTTP) behind one interface
+frontend/index.html  UI shell
+frontend/styles.css  Dark theme
+frontend/app.js      Mic capture + WebSocket + Web Audio playback
 pyproject.toml     Dependencies
 ```
 
 ## A note on latency
 
-The first audio after you start speaking takes roughly 0.5–1.5 seconds to play. Most of that is the TTS model's first-byte time - it needs to see a few tokens before producing audio. The pre-warm shaves about 400ms off the median. The backend pipeline itself adds under 5ms.
+With the Soniox provider, the first audio after you start speaking takes roughly 0.5–1.5 seconds to play. Most of that is the TTS model's first-byte time - it needs to see a few tokens before producing audio. The pre-warm shaves about 400ms off the median. The backend pipeline itself adds under 5ms.
+
+The 60db provider uses the simple (non-streaming) `POST /tts-synthesize` endpoint, so it synthesizes a whole utterance per request: audio for an utterance starts only once that utterance's text is complete and the request returns. That's simpler but higher-latency than streaming; switch to Soniox if you need token-level streaming.

--- a/apps/soniox-speech-to-speech-translation-demo/main.py
+++ b/apps/soniox-speech-to-speech-translation-demo/main.py
@@ -1,13 +1,20 @@
-import os, json, asyncio, base64, websockets, httpx
+import os, json, asyncio, websockets, httpx
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from dotenv import load_dotenv
+
+from tts import make_tts_backend
 
 load_dotenv(override=True)
 
 SONIOX_API_KEY = os.environ["SONIOX_API_KEY"]
 STT_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
-TTS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+
+# TTS provider selection. Defaults to 60db; set to "soniox" for Soniox TTS.
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "sixtydb")
+SIXTYDB_API_KEY = os.getenv("SIXTYDB_API_KEY", "")
+SIXTYDB_VOICE_ID = os.getenv("SIXTYDB_VOICE_ID", "")
+SIXTYDB_API_BASE = os.getenv("SIXTYDB_API_BASE", "https://api.60db.ai")
 
 app = FastAPI()
 
@@ -25,18 +32,6 @@ def get_stt_config(diarization: bool, lang_id: bool, target: str) -> dict:
     }
 
 
-def get_tts_config(stream_id: str, voice: str, lang: str) -> dict:
-    return {
-        "api_key": SONIOX_API_KEY,
-        "stream_id": stream_id,
-        "model": "tts-rt-v1",
-        "voice": voice,
-        "language": lang,
-        "audio_format": "pcm_s16le",
-        "sample_rate": 24000,
-    }
-
-
 @app.websocket("/ws/translate")
 async def translation_websocket(
     browser_ws: WebSocket,
@@ -50,15 +45,15 @@ async def translation_websocket(
 ) -> None:
     await browser_ws.accept()
     stt_ws = None
-    tts_ws = None
+    tts_backend = None
     stt_config = get_stt_config(
         diarization=diarize, lang_id=lang_id, target=target_lang
     )
     # Queue decouples STT producing tokens from TTS consuming them — important
     # when the source speaks faster than TTS can synthesize.
     tts_queue = asyncio.Queue() if tts else None
-    # Shared between handle_stt (sets stt_done), tts_sender (writes current_stream_id),
-    # and pipe_tts_to_browser (reads both to decide when the session is over).
+    # Shared with the TTS backend: handle_stt sets stt_done; the Soniox backend
+    # uses current_stream_id to decide when the session's final audio has played.
     tts_state = {"current_stream_id": None, "stt_done": False}
     try:
         stt_ws = await websockets.connect(STT_URL)
@@ -75,25 +70,18 @@ async def translation_websocket(
             input_coro = pipe_browser_audio_to_stt(browser_ws=browser_ws, stt_ws=stt_ws)
 
         if tts:
-            tts_ws = await websockets.connect(TTS_URL)
-
-            tts_idle = asyncio.Event()
-            tts_idle.set()  # default: no stream open, free to open one
-
-            # Pre-open a TTS stream so the first utterance doesn't pay the
-            # round-trip for stream setup.
-            try:
-                await tts_ws.send(
-                    json.dumps(
-                        get_tts_config(
-                            stream_id="prewarm", voice=voice, lang=target_lang
-                        )
-                    )
-                )
-                tts_state["current_stream_id"] = "prewarm"
-                tts_idle.clear()
-            except websockets.WebSocketException:
-                pass
+            # The backend (Soniox WebSocket or 60db HTTP) is interchangeable: it
+            # consumes translated text from tts_queue and streams PCM to the
+            # browser. The rest of the handler doesn't care which one is used.
+            tts_backend = make_tts_backend(
+                TTS_PROVIDER,
+                voice=voice,
+                target_lang=target_lang,
+                soniox_api_key=SONIOX_API_KEY,
+                sixtydb_api_key=SIXTYDB_API_KEY,
+                sixtydb_voice_id=SIXTYDB_VOICE_ID,
+                sixtydb_base_url=SIXTYDB_API_BASE,
+            )
 
         async with asyncio.TaskGroup() as tg:
             tg.create_task(input_coro)
@@ -107,32 +95,20 @@ async def translation_websocket(
             )
             if tts:
                 tg.create_task(
-                    tts_sender(
+                    tts_backend.run(
                         tts_queue=tts_queue,
-                        tts_idle=tts_idle,
-                        tts_state=tts_state,
-                        tts_ws=tts_ws,
-                        target_lang=target_lang,
-                        voice=voice,
-                    )
-                )
-                tg.create_task(
-                    pipe_tts_to_browser(
-                        tts_ws=tts_ws,
                         browser_ws=browser_ws,
-                        tts_idle=tts_idle,
                         tts_state=tts_state,
                     )
                 )
-                tg.create_task(tts_keepalive(tts_ws=tts_ws))
 
     except* WebSocketDisconnect:
         pass
     finally:
         if stt_ws is not None:
             await stt_ws.close()
-        if tts_ws is not None:
-            await tts_ws.close()
+        if tts_backend is not None:
+            await tts_backend.aclose()
 
 
 async def pipe_browser_audio_to_stt(browser_ws: WebSocket, stt_ws) -> None:
@@ -207,7 +183,7 @@ async def handle_stt(
         print(f"Error {e}")
     finally:
         if tts_queue is not None:
-            # Signal tts_sender to wrap up: close any open stream, then exit.
+            # Signal the TTS backend to wrap up: flush the last utterance, then exit.
             await tts_queue.put(("end", None))
             await tts_queue.put(None)
         tts_state["stt_done"] = True
@@ -221,110 +197,4 @@ async def handle_stt(
                 pass
 
 
-async def tts_sender(
-    tts_queue: asyncio.Queue,
-    tts_idle: asyncio.Event,
-    tts_state: dict,
-    tts_ws,
-    target_lang: str,
-    voice: str,
-) -> None:
-    stream_counter = 0
-    current_stream_used = False
-    try:
-        while True:
-            data = await tts_queue.get()
-
-            if data is None:
-                break
-
-            kind, payload = data
-            if kind == "text":
-                # Open a new stream if needed
-                if tts_state["current_stream_id"] is None:
-                    await tts_idle.wait()
-                    stream_counter += 1
-                    tts_state["current_stream_id"] = f"utterance-{stream_counter}"
-                    config = get_tts_config(
-                        stream_id=tts_state["current_stream_id"],
-                        voice=voice,
-                        lang=target_lang,
-                    )
-                    await tts_ws.send(json.dumps(config))
-                # Send the text chunk
-                pkg = {
-                    "stream_id": tts_state["current_stream_id"],
-                    "text": payload,
-                    "text_end": False,
-                }
-                await tts_ws.send(json.dumps(pkg))
-                current_stream_used = True
-            elif kind == "end":
-                if tts_state["current_stream_id"] is not None and current_stream_used:
-                    tts_idle.clear()  # mark stream as still draining
-                    pkg = {
-                        "stream_id": tts_state["current_stream_id"],
-                        "text": "",
-                        "text_end": True,
-                    }
-                    await tts_ws.send(json.dumps(pkg))
-                    tts_state["current_stream_id"] = None
-                    current_stream_used = False
-    except websockets.ConnectionClosedOK:
-        pass
-    except websockets.ConnectionClosedError as e:
-        print(f"TTS WS closed: {e}")
-
-
-async def pipe_tts_to_browser(
-    tts_ws,
-    browser_ws: WebSocket,
-    tts_idle: asyncio.Event,
-    tts_state: dict,
-) -> None:
-    try:
-        while True:
-            message = await tts_ws.recv()
-            data = json.loads(message)
-
-            if data.get("error_code") is not None:
-                print(
-                    f"Error in stream_id {data['stream_id']}: {data['error_code']} - {data['error_message']}"
-                )
-
-            audio_b64 = data.get("audio")
-            if audio_b64:
-                await browser_ws.send_bytes(base64.b64decode(audio_b64))
-
-            if data.get("terminated"):
-                tts_idle.set()
-                if data["stream_id"] == tts_state["current_stream_id"]:
-                    tts_state["current_stream_id"] = None
-                # Once STT is finished and no stream remains open, this
-                # terminated event marked the very last TTS audio of the
-                # session — tell the browser it's safe to stop.
-                if tts_state["stt_done"] and tts_state["current_stream_id"] is None:
-                    try:
-                        await browser_ws.send_json({"session_done": True})
-                    except Exception:
-                        pass
-                    await tts_ws.close()
-                    break
-    except (WebSocketDisconnect, RuntimeError, websockets.ConnectionClosedOK):
-        pass
-    except websockets.ConnectionClosedError as e:
-        print(f"Error {e}")
-
-
-async def tts_keepalive(tts_ws):
-    try:
-        while True:
-            await asyncio.sleep(20)
-            await tts_ws.send(json.dumps({"keep_alive": True}))
-    except websockets.ConnectionClosedOK:
-        pass
-    except websockets.ConnectionClosedError as e:
-        print(f"TTS WS closed: {e}")
-
-
-app.mount("/", StaticFiles(directory="web", html=True), name="static")
+app.mount("/", StaticFiles(directory="frontend", html=True), name="static")

--- a/apps/soniox-speech-to-speech-translation-demo/tts.py
+++ b/apps/soniox-speech-to-speech-translation-demo/tts.py
@@ -1,0 +1,416 @@
+"""Text-to-speech backends for the speech-to-speech demo.
+
+The WebSocket handler in ``main.py`` is provider-agnostic: it pushes translated
+text onto a queue and lets a *backend* turn that into PCM audio frames which are
+streamed to the browser. Two backends are provided behind a common
+:class:`TtsBackend` interface:
+
+- :class:`SonioxTtsBackend`  – Soniox real-time streaming TTS over WebSocket.
+- :class:`SixtyDBTtsBackend` – 60db HTTP TTS (``POST /tts-synthesize``).
+
+Both emit raw little-endian 16-bit PCM at 24 kHz, which is exactly what the
+browser plays (see ``frontend/app.js``), so they are interchangeable.
+
+Queue protocol (items put on ``tts_queue`` by ``handle_stt``):
+- ``("text", str)`` – a chunk of translated text for the current utterance.
+- ``("end", None)`` – the current utterance is complete; flush/synthesize it.
+- ``None``          – no more input; finish up and signal ``session_done``.
+"""
+
+import abc
+import asyncio
+import base64
+import io
+import json
+import sys
+import wave
+from array import array
+
+import httpx
+import websockets
+from fastapi import WebSocket, WebSocketDisconnect
+
+SONIOX_TTS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+SIXTYDB_DEFAULT_BASE_URL = "https://api.60db.ai"
+TTS_SAMPLE_RATE = 24000
+
+DEFAULT_PROVIDER = "sixtydb"
+
+# ~40 ms of PCM per browser frame (24000 Hz * 2 bytes * 0.04 s = 1920 bytes).
+_CHUNK_BYTES = int(TTS_SAMPLE_RATE * 2 * 0.04) & ~1
+
+
+class TtsBackend(abc.ABC):
+    """Consumes translated text from ``tts_queue`` and streams PCM to the browser."""
+
+    @abc.abstractmethod
+    async def run(
+        self,
+        tts_queue: asyncio.Queue,
+        browser_ws: WebSocket,
+        tts_state: dict,
+    ) -> None:
+        ...
+
+    async def aclose(self) -> None:
+        """Release any resources (sockets, HTTP clients). Safe to call twice."""
+
+
+# ---------------------------------------------------------------------------
+# Soniox streaming WebSocket backend
+# ---------------------------------------------------------------------------
+
+
+class SonioxTtsBackend(TtsBackend):
+    """Real-time Soniox TTS. Streams text tokens per utterance over a WebSocket."""
+
+    def __init__(self, api_key: str, voice: str, target_lang: str):
+        self._api_key = api_key
+        self._voice = voice
+        self._target_lang = target_lang
+        self._ws = None
+
+    def _config(self, stream_id: str) -> dict:
+        return {
+            "api_key": self._api_key,
+            "stream_id": stream_id,
+            "model": "tts-rt-v1",
+            "voice": self._voice,
+            "language": self._target_lang,
+            "audio_format": "pcm_s16le",
+            "sample_rate": TTS_SAMPLE_RATE,
+        }
+
+    async def run(self, tts_queue, browser_ws, tts_state):
+        self._ws = await websockets.connect(SONIOX_TTS_URL)
+
+        tts_idle = asyncio.Event()
+        tts_idle.set()  # default: no stream open, free to open one
+
+        # Pre-open a TTS stream so the first utterance doesn't pay the
+        # round-trip for stream setup.
+        try:
+            await self._ws.send(json.dumps(self._config("prewarm")))
+            tts_state["current_stream_id"] = "prewarm"
+            tts_idle.clear()
+        except websockets.WebSocketException:
+            pass
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(self._sender(tts_queue, tts_idle, tts_state))
+            tg.create_task(self._pipe(browser_ws, tts_idle, tts_state))
+            tg.create_task(self._keepalive())
+
+    async def aclose(self):
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def _sender(self, tts_queue, tts_idle, tts_state):
+        stream_counter = 0
+        current_stream_used = False
+        try:
+            while True:
+                data = await tts_queue.get()
+
+                if data is None:
+                    break
+
+                kind, payload = data
+                if kind == "text":
+                    # Open a new stream if needed
+                    if tts_state["current_stream_id"] is None:
+                        await tts_idle.wait()
+                        stream_counter += 1
+                        tts_state["current_stream_id"] = f"utterance-{stream_counter}"
+                        await self._ws.send(
+                            json.dumps(self._config(tts_state["current_stream_id"]))
+                        )
+                    # Send the text chunk
+                    pkg = {
+                        "stream_id": tts_state["current_stream_id"],
+                        "text": payload,
+                        "text_end": False,
+                    }
+                    await self._ws.send(json.dumps(pkg))
+                    current_stream_used = True
+                elif kind == "end":
+                    if (
+                        tts_state["current_stream_id"] is not None
+                        and current_stream_used
+                    ):
+                        tts_idle.clear()  # mark stream as still draining
+                        pkg = {
+                            "stream_id": tts_state["current_stream_id"],
+                            "text": "",
+                            "text_end": True,
+                        }
+                        await self._ws.send(json.dumps(pkg))
+                        tts_state["current_stream_id"] = None
+                        current_stream_used = False
+        except websockets.ConnectionClosedOK:
+            pass
+        except websockets.ConnectionClosedError as e:
+            print(f"TTS WS closed: {e}")
+
+    async def _pipe(self, browser_ws, tts_idle, tts_state):
+        try:
+            while True:
+                message = await self._ws.recv()
+                data = json.loads(message)
+
+                if data.get("error_code") is not None:
+                    print(
+                        f"Error in stream_id {data['stream_id']}: "
+                        f"{data['error_code']} - {data['error_message']}"
+                    )
+
+                audio_b64 = data.get("audio")
+                if audio_b64:
+                    await browser_ws.send_bytes(base64.b64decode(audio_b64))
+
+                if data.get("terminated"):
+                    tts_idle.set()
+                    if data["stream_id"] == tts_state["current_stream_id"]:
+                        tts_state["current_stream_id"] = None
+                    # Once STT is finished and no stream remains open, this
+                    # terminated event marked the very last TTS audio of the
+                    # session — tell the browser it's safe to stop.
+                    if (
+                        tts_state["stt_done"]
+                        and tts_state["current_stream_id"] is None
+                    ):
+                        await _send_session_done(browser_ws)
+                        await self._ws.close()
+                        break
+        except (WebSocketDisconnect, RuntimeError, websockets.ConnectionClosedOK):
+            pass
+        except websockets.ConnectionClosedError as e:
+            print(f"Error {e}")
+
+    async def _keepalive(self):
+        try:
+            while True:
+                await asyncio.sleep(20)
+                await self._ws.send(json.dumps({"keep_alive": True}))
+        except websockets.ConnectionClosedOK:
+            pass
+        except websockets.ConnectionClosedError as e:
+            print(f"TTS WS closed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 60db HTTP backend
+# ---------------------------------------------------------------------------
+
+
+class SixtyDBTtsBackend(TtsBackend):
+    """60db TTS via the simple ``POST /tts-synthesize`` endpoint.
+
+    Accumulates text per utterance and synthesizes it in one request when the
+    utterance ends, then streams the resulting PCM to the browser in small frames.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        voice_id: str,
+        base_url: str = SIXTYDB_DEFAULT_BASE_URL,
+        speed: float = 1.0,
+        stability: int = 50,
+        similarity: int = 75,
+        enhance: bool = True,
+    ):
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._base_url = base_url.rstrip("/")
+        self._speed = speed
+        self._stability = stability
+        self._similarity = similarity
+        self._enhance = enhance
+        self._client: httpx.AsyncClient | None = None
+
+    async def run(self, tts_queue, browser_ws, tts_state):
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        buffer: list[str] = []
+        try:
+            while True:
+                item = await tts_queue.get()
+                if item is None:
+                    await self._flush(buffer, browser_ws)
+                    break
+                kind, payload = item
+                if kind == "text":
+                    buffer.append(payload)
+                elif kind == "end":
+                    await self._flush(buffer, browser_ws)
+                    buffer = []
+        finally:
+            await _send_session_done(browser_ws)
+
+    async def aclose(self):
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _flush(self, buffer: list[str], browser_ws):
+        text = "".join(buffer).strip()
+        if not text or self._client is None:
+            return
+        try:
+            pcm = await _synthesize_pcm(
+                self._client,
+                api_key=self._api_key,
+                text=text,
+                voice_id=self._voice_id,
+                base_url=self._base_url,
+                speed=self._speed,
+                stability=self._stability,
+                similarity=self._similarity,
+                enhance=self._enhance,
+            )
+        except (httpx.HTTPError, ValueError) as e:
+            print(f"60db TTS request failed: {e}")
+            try:
+                await browser_ws.send_json(
+                    {"error_code": "tts_failed", "error_message": str(e)}
+                )
+            except Exception:
+                pass
+            return
+
+        for offset in range(0, len(pcm), _CHUNK_BYTES):
+            await browser_ws.send_bytes(pcm[offset : offset + _CHUNK_BYTES])
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def make_tts_backend(
+    provider: str,
+    *,
+    voice: str,
+    target_lang: str,
+    soniox_api_key: str,
+    sixtydb_api_key: str = "",
+    sixtydb_voice_id: str = "",
+    sixtydb_base_url: str = SIXTYDB_DEFAULT_BASE_URL,
+) -> TtsBackend:
+    """Build the TTS backend for ``provider`` ("soniox" or "sixtydb")."""
+    name = (provider or DEFAULT_PROVIDER).strip().lower()
+
+    if name == "soniox":
+        return SonioxTtsBackend(
+            api_key=soniox_api_key, voice=voice, target_lang=target_lang
+        )
+    if name in ("sixtydb", "60db"):
+        return SixtyDBTtsBackend(
+            api_key=sixtydb_api_key,
+            voice_id=sixtydb_voice_id,
+            base_url=sixtydb_base_url or SIXTYDB_DEFAULT_BASE_URL,
+        )
+    raise ValueError(
+        f"Unknown TTS_PROVIDER '{provider}'. Expected 'soniox' or 'sixtydb'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _send_session_done(browser_ws: WebSocket) -> None:
+    try:
+        await browser_ws.send_json({"session_done": True})
+    except Exception:
+        pass
+
+
+async def _synthesize_pcm(
+    client: httpx.AsyncClient,
+    *,
+    api_key: str,
+    text: str,
+    voice_id: str,
+    base_url: str,
+    speed: float,
+    stability: int,
+    similarity: int,
+    enhance: bool,
+) -> bytes:
+    """Synthesize ``text`` via 60db and return raw PCM s16le at 24 kHz."""
+    response = await client.post(
+        f"{base_url}/tts-synthesize",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={
+            "text": text,
+            "voice_id": voice_id,
+            "speed": speed,
+            "stability": stability,
+            "similarity": similarity,
+            "enhance": enhance,
+            "output_format": "wav",
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    audio_b64 = payload.get("audio_base64")
+    if not audio_b64:
+        raise ValueError("60db response did not contain 'audio_base64'")
+    return _wav_to_pcm_s16le(base64.b64decode(audio_b64), TTS_SAMPLE_RATE)
+
+
+def _wav_to_pcm_s16le(wav_bytes: bytes, target_rate: int) -> bytes:
+    """Unwrap a WAV container into raw little-endian 16-bit mono PCM.
+
+    Python 3.13 removed ``audioop``, so down-mixing/resampling is done in pure
+    Python. In the common case (mono 16-bit at ``target_rate``) this is a no-op
+    beyond stripping the WAV header.
+    """
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        num_channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        framerate = wav.getframerate()
+        frames = wav.readframes(wav.getnframes())
+
+    if sample_width == 2:
+        samples = array("h")
+        samples.frombytes(frames)
+    elif sample_width == 1:
+        samples = array("h", (((b - 128) << 8) for b in frames))
+    else:
+        raise ValueError(f"Unsupported 60db WAV sample width: {sample_width} bytes")
+
+    if num_channels > 1:
+        mono = array("h", bytes(2 * (len(samples) // num_channels)))
+        for i in range(len(mono)):
+            base = i * num_channels
+            mono[i] = int(
+                sum(samples[base + c] for c in range(num_channels)) / num_channels
+            )
+        samples = mono
+
+    samples = _resample_linear(samples, framerate or target_rate, target_rate)
+
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return samples.tobytes()
+
+
+def _resample_linear(samples: array, src_rate: int, dst_rate: int) -> array:
+    if src_rate == dst_rate or len(samples) == 0:
+        return samples
+    n = len(samples)
+    out_n = max(1, round(n * dst_rate / src_rate))
+    out = array("h", bytes(2 * out_n))
+    ratio = src_rate / dst_rate
+    for i in range(out_n):
+        pos = i * ratio
+        i0 = int(pos)
+        frac = pos - i0
+        s0 = samples[i0] if i0 < n else samples[-1]
+        s1 = samples[i0 + 1] if i0 + 1 < n else s0
+        out[i] = int(s0 + (s1 - s0) * frac)
+    return out

--- a/apps/soniox-voice-bot-demo/server/.env.example
+++ b/apps/soniox-voice-bot-demo/server/.env.example
@@ -1,4 +1,19 @@
+# Soniox is used for speech-to-text (and optionally text-to-speech).
 SONIOX_API_KEY=
 
+# OpenAI is used for the large language model.
 OPENAI_API_KEY=
 OPENAI_MODEL=
+
+# Text-to-speech provider: "sixtydb" (default) or "soniox".
+TTS_PROVIDER=sixtydb
+
+# 60db TTS (used when TTS_PROVIDER=sixtydb).
+SIXTYDB_API_KEY=
+SIXTYDB_VOICE_ID=
+# SIXTYDB_API_BASE=https://api.60db.ai
+
+# Soniox TTS (used when TTS_PROVIDER=soniox). Falls back to SONIOX_API_KEY /
+# the default host if left blank.
+# SONIOX_API_KEY_TTS=
+# SONIOX_API_HOST_TTS=wss://tts-rt.soniox.com/tts-websocket

--- a/apps/soniox-voice-bot-demo/server/README.md
+++ b/apps/soniox-voice-bot-demo/server/README.md
@@ -18,7 +18,9 @@ The service consists of four main components that process messages concurrently:
 - **Voice Activity Detection (VAD) Processor**: Uses Silero VAD to detect speech boundaries in incoming audio. Emits `UserSpeechStartMessage` and `UserSpeechEndMessage` events to interrupt TTS when the user starts speaking.
 - **Speech-to-Text (STT) Processor**: Receives the raw audio from the user and uses the Soniox API to convert it into text tokens in real-time. It generates `TranscriptionMessage` events as the user speaks.
 - **Language Model (LLM) Processor**: Receives transcription messages, manages the conversation history, and uses a large language model to decide what to do next. It can either generate a direct text response or use one of the provided tools.
-- **Text-to-Speech (TTS) Processor**: Receives streaming text chunks from the LLM and uses the Soniox API to convert them into audible speech in real-time, streaming audio back to the user as it's generated.
+- **Text-to-Speech (TTS) Processor**: Converts the LLM's text into audible speech and streams the audio (raw 16-bit PCM) back to the user. Two interchangeable providers are available behind the same `MessageProcessor` interface, selected with the `TTS_PROVIDER` env var:
+  - `soniox` — Soniox streaming WebSocket TTS (`SonioxTTSProcessor`), synthesizing as the LLM streams.
+  - `sixtydb` *(default)* — 60db HTTP TTS (`SixtyDBTTSProcessor`), synthesizing each completed turn via `POST /tts-synthesize`. The provider is chosen by `processors/tts_provider.py`, so the rest of the app is provider-agnostic.
 
 ### Data & session flow
 
@@ -59,11 +61,20 @@ Messages intended for the user (like transcription updates, LLM text chunks, or 
    Copy `.env.example` to `.env` and fill in your API keys:
 
    ```sh
-   # Soniox is used for speech-to-text and text-to-speech
+   # Soniox is used for speech-to-text (and TTS when TTS_PROVIDER=soniox)
    SONIOX_API_KEY=your_soniox_key
    # OpenAI is used for the large language model
    OPENAI_API_KEY=your_openai_key
+
+   # TTS provider: "sixtydb" (default) or "soniox"
+   TTS_PROVIDER=sixtydb
+   # 60db TTS (used when TTS_PROVIDER=sixtydb)
+   SIXTYDB_API_KEY=your_60db_key
+   SIXTYDB_VOICE_ID=your_60db_voice_id
    ```
+
+   > 60db's voice is set with `SIXTYDB_VOICE_ID`; the `voice` query param only
+   > applies to the Soniox provider.
 
 4. **Run the backend server:**
 

--- a/apps/soniox-voice-bot-demo/server/main.py
+++ b/apps/soniox-voice-bot-demo/server/main.py
@@ -17,7 +17,7 @@ from messages import ErrorMessage
 from processors.llm import LLMProcessor
 from processors.message_processor import MessageProcessor
 from processors.stt import STTProcessor
-from processors.tts import TTSProcessor
+from processors.tts_provider import make_tts_processor
 from processors.vad import VADProcessor
 from session import Session
 from tools import (
@@ -36,8 +36,17 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.4-mini")
 
-SONIOX_API_KEY_TTS = os.getenv("SONIOX_API_KEY_TTS", "")
+# TTS provider selection. Defaults to 60db; set to "soniox" for Soniox TTS.
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "sixtydb")
+
+# Soniox TTS uses a separate key/host by default, falling back to the main key.
+SONIOX_API_KEY_TTS = os.getenv("SONIOX_API_KEY_TTS", "") or SONIOX_API_KEY
 SONIOX_API_HOST_TTS = os.getenv("SONIOX_API_HOST_TTS", "")
+
+# 60db TTS configuration.
+SIXTYDB_API_KEY = os.getenv("SIXTYDB_API_KEY", "")
+SIXTYDB_VOICE_ID = os.getenv("SIXTYDB_VOICE_ID", "")
+SIXTYDB_API_BASE = os.getenv("SIXTYDB_API_BASE", "https://api.60db.ai")
 
 
 class QueryParams(pydantic.BaseModel):
@@ -112,12 +121,16 @@ async def handle(websocket: ServerConnection):
             system_message=get_system_message(LANGUAGES_MAP[params.language]),
             tools=get_tools(),
         ),
-        TTSProcessor(
-            api_key=SONIOX_API_KEY_TTS,
-            api_host=SONIOX_API_HOST_TTS,
+        make_tts_processor(
+            TTS_PROVIDER,
             language=params.language,
-            sample_rate=params.audio_out_sample_rate,
             voice=params.voice,
+            sample_rate=params.audio_out_sample_rate,
+            soniox_api_key=SONIOX_API_KEY_TTS,
+            soniox_api_host=SONIOX_API_HOST_TTS,
+            sixtydb_api_key=SIXTYDB_API_KEY,
+            sixtydb_voice_id=SIXTYDB_VOICE_ID,
+            sixtydb_base_url=SIXTYDB_API_BASE,
         ),
     ]
 

--- a/apps/soniox-voice-bot-demo/server/processors/sixtydb_client.py
+++ b/apps/soniox-voice-bot-demo/server/processors/sixtydb_client.py
@@ -1,0 +1,141 @@
+"""Thin client for the 60db Text-to-Speech HTTP API.
+
+The voice bot's audio path (browser worklet, Twilio bridge) consumes **raw
+little-endian 16-bit PCM**. 60db's simple synthesis endpoint
+(``POST /tts-synthesize``) instead returns a complete, base64-encoded container
+file (mp3/wav/ogg/flac). We therefore request ``wav`` and unwrap it back to raw
+PCM here so the rest of the app stays format-agnostic — it only ever sees PCM
+``s16le`` at the configured sample rate, exactly like the Soniox provider emits.
+
+Python 3.13 removed the ``audioop`` module, so the small amount of channel
+down-mixing / resampling we may need is implemented in pure Python below. In the
+common case (60db already returns mono 16-bit at the requested rate) these are
+no-ops.
+"""
+
+import base64
+import io
+import wave
+from array import array
+
+import httpx
+
+DEFAULT_BASE_URL = "https://api.60db.ai"
+
+# 60db's documented synthesis sample rate. Used only as a fallback if the
+# returned WAV omits/!= the target; we resample to the app's sample rate.
+DEFAULT_SAMPLE_RATE = 24000
+
+
+def _to_int16_mono(frames: bytes, sample_width: int, num_channels: int) -> array:
+    """Decode raw WAV frames into a mono ``array('h')`` of 16-bit samples."""
+    if sample_width == 2:
+        samples = array("h")
+        samples.frombytes(frames)
+    elif sample_width == 1:
+        # 8-bit WAV is unsigned; center around 0 and scale up to 16-bit.
+        samples = array("h", (((b - 128) << 8) for b in frames))
+    else:
+        raise ValueError(
+            f"Unsupported 60db WAV sample width: {sample_width} bytes "
+            "(expected 1 or 2)"
+        )
+
+    if num_channels == 1:
+        return samples
+    if num_channels < 1:
+        raise ValueError(f"Invalid channel count in 60db WAV: {num_channels}")
+
+    # Down-mix to mono by averaging the interleaved channels.
+    mono = array("h", bytes(2 * (len(samples) // num_channels)))
+    for i in range(len(mono)):
+        base = i * num_channels
+        total = 0
+        for c in range(num_channels):
+            total += samples[base + c]
+        mono[i] = int(total / num_channels)
+    return mono
+
+
+def _resample_linear(samples: array, src_rate: int, dst_rate: int) -> array:
+    """Linearly resample a mono 16-bit signal. No-op when the rates match."""
+    if src_rate == dst_rate or len(samples) == 0:
+        return samples
+
+    n = len(samples)
+    out_n = max(1, round(n * dst_rate / src_rate))
+    out = array("h", bytes(2 * out_n))
+    ratio = src_rate / dst_rate
+    for i in range(out_n):
+        pos = i * ratio
+        i0 = int(pos)
+        frac = pos - i0
+        s0 = samples[i0] if i0 < n else samples[-1]
+        s1 = samples[i0 + 1] if i0 + 1 < n else s0
+        out[i] = int(s0 + (s1 - s0) * frac)
+    return out
+
+
+def wav_to_pcm_s16le(wav_bytes: bytes, target_rate: int) -> bytes:
+    """Unwrap a WAV container into raw little-endian 16-bit mono PCM."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        num_channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        framerate = wav.getframerate()
+        frames = wav.readframes(wav.getnframes())
+
+    samples = _to_int16_mono(frames, sample_width, num_channels)
+    samples = _resample_linear(samples, framerate or target_rate, target_rate)
+
+    # ``array('h')`` is host byte order; the consumers expect little-endian.
+    import sys
+
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return samples.tobytes()
+
+
+async def synthesize_pcm(
+    client: httpx.AsyncClient,
+    *,
+    api_key: str,
+    text: str,
+    voice_id: str,
+    base_url: str = DEFAULT_BASE_URL,
+    target_rate: int = DEFAULT_SAMPLE_RATE,
+    speed: float = 1.0,
+    stability: int = 50,
+    similarity: int = 75,
+    enhance: bool = True,
+) -> bytes:
+    """Synthesize ``text`` via 60db and return raw PCM ``s16le`` at ``target_rate``.
+
+    Uses the simple (non-streaming) ``POST /tts-synthesize`` endpoint, which
+    returns the full clip in one response.
+    """
+    response = await client.post(
+        f"{base_url.rstrip('/')}/tts-synthesize",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={
+            "text": text,
+            "voice_id": voice_id,
+            "speed": speed,
+            "stability": stability,
+            "similarity": similarity,
+            "enhance": enhance,
+            # Request a container we can losslessly unwrap to raw PCM.
+            "output_format": "wav",
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    audio_b64 = payload.get("audio_base64")
+    if not audio_b64:
+        raise ValueError("60db response did not contain 'audio_base64'")
+
+    sample_rate = int(payload.get("sample_rate") or target_rate)
+    wav_bytes = base64.b64decode(audio_b64)
+    # The WAV header already carries the true rate; pass the response rate only
+    # as a fallback for headerless edge cases.
+    return wav_to_pcm_s16le(wav_bytes, target_rate or sample_rate)

--- a/apps/soniox-voice-bot-demo/server/processors/tts.py
+++ b/apps/soniox-voice-bot-demo/server/processors/tts.py
@@ -25,8 +25,8 @@ DEFAULT_AUDIO_FORMAT = "pcm_s16le"
 DEFAULT_SAMPLE_RATE = 24000
 
 
-class TTSProcessor(MessageProcessor):
-    """Processor that converts LLM text output to speech using streaming TTS."""
+class SonioxTTSProcessor(MessageProcessor):
+    """Processor that converts LLM text output to speech using Soniox streaming TTS."""
 
     def __init__(
         self,
@@ -243,3 +243,9 @@ class TTSProcessor(MessageProcessor):
         except websockets.exceptions.ConnectionClosed:
             # Expected when closing the connection
             self.log.debug("Connection to Soniox API closed")
+
+
+# Backwards-compatible alias: this module used to export a single ``TTSProcessor``.
+# 60db is now available as an alternative provider (see ``tts_sixtydb.py`` and
+# ``tts_provider.py``), so the Soniox implementation has an explicit name.
+TTSProcessor = SonioxTTSProcessor

--- a/apps/soniox-voice-bot-demo/server/processors/tts_provider.py
+++ b/apps/soniox-voice-bot-demo/server/processors/tts_provider.py
@@ -1,0 +1,67 @@
+"""Factory that selects a TTS provider behind the common ``MessageProcessor``
+interface, so the rest of the app is provider-agnostic.
+
+Supported providers (``TTS_PROVIDER`` env var):
+- ``soniox``  -> Soniox streaming WebSocket TTS (:class:`SonioxTTSProcessor`)
+- ``sixtydb`` -> 60db HTTP TTS (:class:`SixtyDBTTSProcessor`); also accepts ``60db``
+"""
+
+from processors.message_processor import MessageProcessor
+from processors.sixtydb_client import DEFAULT_BASE_URL as SIXTYDB_DEFAULT_BASE_URL
+from processors.tts import SonioxTTSProcessor
+from processors.tts_sixtydb import SixtyDBTTSProcessor
+
+DEFAULT_PROVIDER = "sixtydb"
+SONIOX_DEFAULT_HOST = "wss://tts-rt.soniox.com/tts-websocket"
+
+
+def make_tts_processor(
+    provider: str,
+    *,
+    language: str,
+    voice: str,
+    sample_rate: int,
+    soniox_api_key: str,
+    soniox_api_host: str = "",
+    sixtydb_api_key: str = "",
+    sixtydb_voice_id: str = "",
+    sixtydb_base_url: str = SIXTYDB_DEFAULT_BASE_URL,
+) -> MessageProcessor:
+    """Build the TTS processor for ``provider``.
+
+    Args:
+        provider: "soniox" or "sixtydb" (case-insensitive; empty -> default).
+        language: BCP-47-ish language code passed to providers that use it.
+        voice: Soniox voice name. 60db ignores this and uses ``sixtydb_voice_id``.
+        sample_rate: Output PCM sample rate in Hz (both providers emit s16le PCM).
+        soniox_api_key: API key for Soniox TTS.
+        soniox_api_host: Soniox TTS WebSocket host (falls back to the default).
+        sixtydb_api_key: API key (Bearer token) for 60db.
+        sixtydb_voice_id: Voice id for 60db.
+        sixtydb_base_url: 60db API base URL.
+
+    Raises:
+        ValueError: if ``provider`` is not recognized.
+    """
+    name = (provider or DEFAULT_PROVIDER).strip().lower()
+
+    if name == "soniox":
+        return SonioxTTSProcessor(
+            api_key=soniox_api_key,
+            api_host=soniox_api_host or SONIOX_DEFAULT_HOST,
+            language=language,
+            voice=voice,
+            sample_rate=sample_rate,
+        )
+
+    if name in ("sixtydb", "60db"):
+        return SixtyDBTTSProcessor(
+            api_key=sixtydb_api_key,
+            voice_id=sixtydb_voice_id,
+            base_url=sixtydb_base_url or SIXTYDB_DEFAULT_BASE_URL,
+            sample_rate=sample_rate,
+        )
+
+    raise ValueError(
+        f"Unknown TTS_PROVIDER '{provider}'. Expected 'soniox' or 'sixtydb'."
+    )

--- a/apps/soniox-voice-bot-demo/server/processors/tts_sixtydb.py
+++ b/apps/soniox-voice-bot-demo/server/processors/tts_sixtydb.py
@@ -1,0 +1,175 @@
+import asyncio
+import time
+
+import httpx
+
+from messages import (
+    ErrorMessage,
+    LLMFullMessage,
+    Message,
+    MetricsMessage,
+    TranscriptionMessage,
+    TTSAudioMessage,
+    UserSpeechStartMessage,
+)
+from processors.message_processor import MessageProcessor
+from processors.sixtydb_client import DEFAULT_BASE_URL, synthesize_pcm
+
+DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_SPEED = 1.0
+DEFAULT_STABILITY = 50
+DEFAULT_SIMILARITY = 75
+DEFAULT_ENHANCE = True
+
+# How much PCM to emit per TTSAudioMessage. The HTTP endpoint returns the whole
+# utterance at once; we slice it into ~40 ms frames so the browser worklet is fed
+# smoothly and so a barge-in can stop playback partway through.
+CHUNK_MS = 40
+
+
+class SixtyDBTTSProcessor(MessageProcessor):
+    """Processor that converts LLM text output to speech using the 60db TTS API.
+
+    Unlike the Soniox provider, 60db's simple endpoint is request/response rather
+    than streaming, so we synthesize once per completed LLM turn
+    (``LLMFullMessage``) and slice the resulting audio into PCM frames. The output
+    is raw ``s16le`` PCM at ``sample_rate`` — identical to what the Soniox
+    processor emits — so this is a drop-in alternative behind ``MessageProcessor``.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        voice_id: str,
+        base_url: str = DEFAULT_BASE_URL,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        speed: float = DEFAULT_SPEED,
+        stability: int = DEFAULT_STABILITY,
+        similarity: int = DEFAULT_SIMILARITY,
+        enhance: bool = DEFAULT_ENHANCE,
+    ):
+        """Initialize the 60db TTS processor.
+
+        Args:
+            api_key: The 60db API key (Bearer token).
+            voice_id: The 60db voice id to synthesize with.
+            base_url: The 60db API base URL. Defaults to "https://api.60db.ai".
+            sample_rate: The output sample rate in Hz. Defaults to 24000.
+            speed: Speech speed multiplier (0.5-2.0). Defaults to 1.0.
+            stability: Voice stability (0-100, lower = more expressive).
+            similarity: Voice similarity/fidelity (0-100).
+            enhance: Whether to apply 60db's audio enhancement.
+        """
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._base_url = base_url
+        self._sample_rate = sample_rate
+        self._speed = speed
+        self._stability = stability
+        self._similarity = similarity
+        self._enhance = enhance
+
+        self._chunk_bytes = max(2, int(sample_rate * 2 * CHUNK_MS / 1000) & ~1)
+
+        self._client: httpx.AsyncClient | None = None
+        self._task: asyncio.Task | None = None
+        # Monotonic generation counter. Bumped on every new turn and on barge-in
+        # so a late HTTP response can detect it has been superseded and drop its
+        # audio instead of talking over the user.
+        self._generation = 0
+
+    async def start(self, send_message, log):
+        self.log = log.bind(processor="tts", provider="sixtydb")
+        self._send_message = send_message
+
+        if not self._api_key:
+            self.log.error("Missing 60db API key (SIXTYDB_API_KEY)")
+        if not self._voice_id:
+            self.log.error("Missing 60db voice id (SIXTYDB_VOICE_ID)")
+
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+
+    async def cleanup(self):
+        self._cancel_generation()
+
+        if self._task:
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def process(self, message: Message):
+        if isinstance(message, LLMFullMessage):
+            # The full turn is available; synthesize it as a single request.
+            # Cancel/invalidate any still-running synthesis from a previous turn.
+            self._cancel_generation()
+            self._generation += 1
+            generation = self._generation
+            self._task = asyncio.create_task(
+                self._synthesize(message.text(), generation)
+            )
+
+        if isinstance(message, UserSpeechStartMessage) or isinstance(
+            message, TranscriptionMessage
+        ):
+            # Stop TTS if any user speech is detected (either with transcription or VAD)
+            self._cancel_generation()
+
+    def _cancel_generation(self):
+        # Bumping the generation invalidates any in-flight/queued audio, and
+        # cancelling the task stops an outstanding HTTP request promptly.
+        self._generation += 1
+        if self._task and not self._task.done():
+            self._task.cancel()
+
+    async def _synthesize(self, text: str, generation: int):
+        text = text.strip()
+        if not text or not self._client:
+            return
+
+        start_time = time.perf_counter()
+        try:
+            pcm = await synthesize_pcm(
+                self._client,
+                api_key=self._api_key,
+                text=text,
+                voice_id=self._voice_id,
+                base_url=self._base_url,
+                target_rate=self._sample_rate,
+                speed=self._speed,
+                stability=self._stability,
+                similarity=self._similarity,
+                enhance=self._enhance,
+            )
+        except asyncio.CancelledError:
+            return
+        except (httpx.HTTPError, ValueError) as e:
+            self.log.error("60db TTS request failed", error=e)
+            if self._send_message:
+                await self._send_message(ErrorMessage("TTS request failed"))
+            return
+
+        # A barge-in (or a newer turn) happened while we were synthesizing — drop
+        # this audio rather than play it over the user.
+        if generation != self._generation:
+            return
+
+        first_chunk_sent = False
+        for offset in range(0, len(pcm), self._chunk_bytes):
+            if generation != self._generation:
+                return
+            chunk = pcm[offset : offset + self._chunk_bytes]
+            if not first_chunk_sent:
+                first_chunk_sent = True
+                first_chunk_ms = (time.perf_counter() - start_time) * 1000
+                await self._send_message(
+                    MetricsMessage("tts_first_chunk_ms", first_chunk_ms)
+                )
+            await self._send_message(TTSAudioMessage(chunk))
+
+        total_ms = (time.perf_counter() - start_time) * 1000
+        await self._send_message(MetricsMessage("tts_total_ms", total_ms))

--- a/apps/soniox-voice-bot-demo/server/pyproject.toml
+++ b/apps/soniox-voice-bot-demo/server/pyproject.toml
@@ -5,6 +5,7 @@ description = "Demo app showcasing how to build a real-time conversational assis
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "httpx>=0.28.1",
     "openai>=1.101.0",
     "python-dotenv>=1.1.1",
     "structlog>=25.4.0",


### PR DESCRIPTION
Added 60dB AI provider support for STT, TTS, and LLM services. The integration follows the existing provider pattern and has been validated with end-to-end voice conversation testing. Looking forward to feedback and review.